### PR TITLE
Add search endpoint to simplify code

### DIFF
--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,0 +1,29 @@
+import { PineconeStore } from "langchain/vectorstores";
+import { OpenAIEmbeddings } from "langchain/embeddings";
+import { PineconeClient } from "@pinecone-database/pinecone";
+import { NextApiRequest, NextApiResponse } from "next";
+
+type Data = {};
+const handler = async (req: NextApiRequest, res: NextApiResponse<Data>) => {
+
+    // Query 
+    const query = req.body.query;
+
+    // Vector DB 
+      const pinecone = new PineconeClient();
+      await pinecone.init({
+        environment: "us-east1-gcp", 
+        apiKey: process.env.PINECONE_API_KEY ?? "",
+      });
+      const index = pinecone.Index("lex-gpt");
+      const vectorStore = await PineconeStore.fromExistingIndex(
+        index,
+        new OpenAIEmbeddings()
+      );
+
+      // Return chunks to display as references 
+      const results = await vectorStore.similaritySearch(query, 4);
+      res.status(200).send(results); 
+    }
+
+export default handler;


### PR DESCRIPTION
Fixes complexity these steps:
+ run VectorDBQAChain
+ get sources chain.returnSourceDocuments=true
+ stream the text (e.g.,  res.write(token) in callbackManager)
+ then return sources (e.g., get and send  responseBody["sourceDocuments"] 

Now, just run ss and populate references.

Then, stream the output text.