### PR TITLE
Add edge runtime to search api and try to mark fs as external

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,4 +11,53 @@ const nextConfig = {
   }
 };
 
+/*
+// 1/ Returns - Module build failed: UnhandledSchemeError: Reading from "node:fs/promises" is not handled by plugins (Unhandled scheme).
+// Import trace for requested module:
+// node:fs/promises
+// ./node_modules/langchain/dist/vectorstores/hnswlib.js
+// ./node_modules/langchain/dist/vectorstores/index.js
+// ./node_modules/langchain/vectorstores.js
+const nodeExternals = require('webpack-node-externals');
+module.exports = {
+  //...
+  externals: [nodeExternals({
+    exclude: ['fs'],
+    debug: true
+  })]
+};
+*/
+
+/*
+// 2/ Same error as above 
+module.exports = {
+  externals: [
+    /node:fs\/promises/,
+  ],
+};
+*/
+
+/*
+// 3/ Can't find API error
+error - PageNotFoundError: Cannot find module for page: /api/search
+    at DevServer.getEdgeFunctionInfo (/Users/31treehaus/Desktop/AI/lex-gpt/node_modules/next/dist/server/next-server.js:1075:23)
+    at DevServer.runEdgeFunction (/Users/31treehaus/Desktop/AI/lex-gpt/node_modules/next/dist/server/next-server.js:1410:25)
+    at async Object.fn (/Users/31treehaus/Desktop/AI/lex-gpt/node_modules/next/dist/server/next-server.js:794:59)
+    at async Router.execute (/Users/31treehaus/Desktop/AI/lex-gpt/node_modules/next/dist/server/router.js:243:32)
+    at async DevServer.runImpl (/Users/31treehaus/Desktop/AI/lex-gpt/node_modules/next/dist/server/base-server.js:432:29)
+    at async DevServer.run (/Users/31treehaus/Desktop/AI/lex-gpt/node_modules/next/dist/server/dev/next-dev-server.js:814:20)
+    at async DevServer.handleRequestImpl (/Users/31treehaus/Desktop/AI/lex-gpt/node_modules/next/dist/server/base-server.js:375:20)
+    at async /Users/31treehaus/Desktop/AI/lex-gpt/node_modules/next/dist/server/base-server.js:157:99 {
+  code: 'ENOENT'
+
+module.exports = {
+  externals: [
+    /node:fs\/promises/,
+    /^\.\/node_modules\/langchain\/dist\/vectorstores\/hnswlib\.js$/,
+    /^\.\/node_modules\/langchain\/dist\/vectorstores\/index\.js$/,
+    /^\.\/node_modules\/langchain\/vectorstores\.js$/,
+  ],
+};
+*/
+
 module.exports = nextConfig;

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -3,9 +3,9 @@ import { OpenAIEmbeddings } from "langchain/embeddings";
 import { PineconeClient } from "@pinecone-database/pinecone";
 import { NextApiRequest, NextApiResponse } from "next";
 
-//export const config = {
-//  runtime: "edge"
-// };
+export const config = {
+  runtime: "edge"
+};
 
 type Data = {};
 const handler = async (req: NextApiRequest, res: NextApiResponse<Data>) => {


### PR DESCRIPTION
Summary - 

1/ We want to enable `edge` runtime w/ Langchain (e.g., for streaming text in this app).

2/ Enabling `edge` fails b/c Langchain is using `fs`:

`Module build failed: UnhandledSchemeError: Reading from "node:fs/promises" is not handled by plugins (Unhandled scheme).`
`Import trace for requested module:`
`node:fs/promises`
`./node_modules/langchain/dist/vectorstores/hnswlib.js`
`./node_modules/langchain/dist/vectorstores/index.js`
`./node_modules/langchain/vectorstores.js`

3/ Discussion w/ @nfcampos indicates that fs usage should be optional.

4/ So, I try various ways of marking `fs` as external, but all fail (traces shown in `next.js.config` coments).

May need support from Vercel folks to debug further.